### PR TITLE
Migrate from miniconda to miniforge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,12 @@
 name: pytorch_base
 channels:
-  - pytorch
-  - nvidia
   - conda-forge
 dependencies:
   - pytorch
+  # make sure that pytorch with CUDA support is installed
+  - pytorch-gpu
   - torchvision
   - torchaudio
-  - pytorch-cuda==12.1  # adjust as needed
+  # If you have a required CUDA version, uncomment and specify the version
+  # - cuda-version=12.6
   - numpy

--- a/initial_setup/install_miniforge.sh
+++ b/initial_setup/install_miniforge.sh
@@ -4,7 +4,7 @@
 
 usage() {
     echo "Usage: $0 [-d <installation_directory>] [-h]"
-    echo "  -d <installation_directory>  Specify the base directory for Miniconda installation (default: ~/)."
+    echo "  -d <installation_directory>  Specify the base directory for Miniforge installation (default: ~/)."
     echo "  -h                           Display this help message."
 }
 
@@ -34,9 +34,9 @@ while getopts ":d:h" opt; do
     esac
 done
 
-mkdir -p ${BASE_DIR}/miniconda3
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ${BASE_DIR}/miniconda3/miniconda.sh
-bash ${BASE_DIR}/miniconda3/miniconda.sh -b -u -p ${BASE_DIR}/miniconda3
-rm -rf ${BASE_DIR}/miniconda3/miniconda.sh
-${BASE_DIR}/miniconda3/bin/conda init bash
-${BASE_DIR}/miniconda3/bin/conda init zsh
+mkdir -p ${BASE_DIR}/miniforge3
+wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh -O ${BASE_DIR}/miniforge3/miniforge.sh
+bash ${BASE_DIR}/miniforge3/miniforge.sh -b -u -p ${BASE_DIR}/miniforge3
+rm -rf ${BASE_DIR}/miniforge3/miniforge.sh
+${BASE_DIR}/miniforge3/bin/conda init bash
+${BASE_DIR}/miniforge3/bin/conda init zsh

--- a/initial_setup/libmamba_solver.sh
+++ b/initial_setup/libmamba_solver.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community
-
-conda update -n base conda
-
-conda install -n base conda-libmamba-solver
-conda config --set solver libmamba

--- a/readme.md
+++ b/readme.md
@@ -2,14 +2,12 @@
 
 ### Initial Setup
 
-Install miniconda and (optional but suggested) set libmamba solver.
+Install miniforge:
 
-- [https://docs.anaconda.com/miniconda/install/](https://docs.anaconda.com/miniconda/install/)
-- [https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community)
+- [https://conda-forge.org/download/](https://conda-forge.org/download/)
 
 Scripts for automatic installation and set up:   
-`./initial_setup/install_miniconda.sh -d <installation_directory>`  
-`./initial_setup/libmamba_solver.sh`  
+`./initial_setup/install_miniforge.sh -d <installation_directory>`  
 
 If not already installed on the cluster, you can install useful things like `TMUX`, `GIT` and `HTOP` directly in 
 `conda base`:
@@ -20,7 +18,7 @@ If not already installed on the cluster, you can install useful things like `TMU
 
 To conclude the setup, install your conda environment with pytorch and cuda support: 
 
-`conda env install -f environment.yml`  
+`conda env create -f environment.yml`  
 
 _Note: adjust cuda version as needed_
 


### PR DESCRIPTION
Hello @SerezD ! 

You repo has started to be used quite a lot in the collaboration between PAVIS and AMI research lines, thanks a lot for working on it. However, for several reasons inside AMI we strongly prefer the use of `conda-forge` packages as opposed to `defaults` conda packages, for several reasons:
* The `defaults` packages can't be used as part of a research institution of a given size (see https://www.theregister.com/2024/08/08/anaconda_puts_the_squeeze_on/)
* On AMI, we distribute many of our robotics libraries on conda-forge, and in general conda-forge and default packages can't be mixed in the same environment (see https://conda-forge.org/docs/user/tipsandtricks/#why-does-that-happen). 
* PyTorch recently discontinued its own conda packages offered on the `pytorch` channel (that were compatible with `defaults`), so in the future the only mantained pytorch conda packages will be the one provided by conda-forge (unfortunatly pytorch docs are not super clear w.r.t. to this, see https://github.com/pytorch/pytorch.github.io/issues/1909)

For these reasons, in this PR I migrate the docs from using `miniconda` to use `miniforge`, from using `pytorch` and `nvidia` channel to just use `conda-forge` channel, and a bit of related cleanup, such as not installing `conda-libmamba-solver` at the solver is installed by default in conda since late 2023, see https://conda.org/blog/2023-11-06-conda-23-10-0-release/ .

If you are not interested in the changes, no problem! We will probably keep them somewhere else for our use internally.

fyi @S-Dafarra @pmorerio @apicis @mtiezzi @carloscp3009 @giotherobot @AriannaPietrasanta

